### PR TITLE
fix: duplicate responses, Docker pytest, and agent acknowledgements

### DIFF
--- a/alembic/versions/b2c3d4e5f6a7_add_conversation_id_to_scheduled_jobs.py
+++ b/alembic/versions/b2c3d4e5f6a7_add_conversation_id_to_scheduled_jobs.py
@@ -1,0 +1,36 @@
+"""add conversation_id to scheduled_jobs
+
+Revision ID: b2c3d4e5f6a7
+Revises: f7a8b9c0d1e2
+Create Date: 2026-03-01 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "f7a8b9c0d1e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scheduled_jobs",
+        sa.Column("conversation_id", sa.String(length=36), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_scheduled_jobs_conversation_id",
+        "scheduled_jobs",
+        "conversations",
+        ["conversation_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_scheduled_jobs_conversation_id", "scheduled_jobs", type_="foreignkey")
+    op.drop_column("scheduled_jobs", "conversation_id")

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -15,7 +15,7 @@ RUN uv sync --no-dev --no-editable && \
     rm -rf /root/.cache/uv /tmp/*
 
 # Test runners the software-dev agent needs when validating changes in cloned repos
-RUN .venv/bin/pip install --no-cache-dir pytest pytest-asyncio pytest-cov
+RUN uv pip install --no-cache-dir pytest pytest-asyncio pytest-cov
 
 # ---------------------------------------------------------------------------
 # Stage 2: Runtime — start from a clean filesystem so Playwright's ~362 MB

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -14,6 +14,9 @@ COPY prompts/ ./prompts/
 RUN uv sync --no-dev --no-editable && \
     rm -rf /root/.cache/uv /tmp/*
 
+# Test runners the software-dev agent needs when validating changes in cloned repos
+RUN .venv/bin/pip install --no-cache-dir pytest pytest-asyncio pytest-cov
+
 # ---------------------------------------------------------------------------
 # Stage 2: Runtime — start from a clean filesystem so Playwright's ~362 MB
 # of system packages can be installed without hitting layer disk limits.

--- a/docker/Dockerfile.worker
+++ b/docker/Dockerfile.worker
@@ -14,8 +14,12 @@ COPY prompts/ ./prompts/
 RUN uv sync --no-dev --no-editable && \
     rm -rf /root/.cache/uv /tmp/*
 
-# Test runners the software-dev agent needs when validating changes in cloned repos
-RUN uv pip install --no-cache-dir pytest pytest-asyncio pytest-cov
+# Test runners the software-dev agent needs when validating changes in cloned repos.
+# Versions are pinned to match uv.lock to avoid supply-chain drift.
+RUN uv pip install --no-cache-dir \
+    "pytest==9.0.2" \
+    "pytest-asyncio==1.3.0" \
+    "pytest-cov==7.0.0"
 
 # ---------------------------------------------------------------------------
 # Stage 2: Runtime — start from a clean filesystem so Playwright's ~362 MB

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,432 @@
+# Angie API Reference
+
+Base URL: `http://localhost:8000`
+
+## Authentication
+
+JWT Bearer tokens via OAuth2. Obtain tokens from `/api/v1/auth/token`.
+Include in requests as `Authorization: Bearer <token>`.
+
+Two endpoints use query-parameter auth instead (for img src / WebSocket use):
+`/api/v1/media/{filename}?token=<jwt>` and `/api/v1/chat/ws?token=<jwt>`.
+
+______________________________________________________________________
+
+## Health
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/health` | No | Basic status check (`{"status": "ok", "service": "angie-api"}`) |
+| GET | `/api/v1/health` | No | Detailed check with DB/Redis connectivity and uptime |
+
+______________________________________________________________________
+
+## Auth (`/api/v1/auth`)
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| POST | `/auth/register` | No | Create account, returns access + refresh tokens |
+| POST | `/auth/token` | No | Login with username/password, returns tokens |
+
+### POST `/auth/register`
+
+**Request:**
+
+```json
+{
+  "email": "user@example.com",
+  "username": "user",
+  "password": "secret",
+  "full_name": "Jane Doe"
+}
+```
+
+**Response (201):**
+
+```json
+{
+  "access_token": "eyJ...",
+  "refresh_token": "eyJ...",
+  "token_type": "bearer"
+}
+```
+
+### POST `/auth/token`
+
+Standard OAuth2 password flow (`application/x-www-form-urlencoded`):
+`username=user&password=secret`
+
+**Response (200):** Same `TokenResponse` as register.
+
+______________________________________________________________________
+
+## Users (`/api/v1/users`)
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/users/me` | Yes | Get current user profile |
+| PATCH | `/users/me` | Yes | Update profile (`full_name`, `timezone`) |
+| POST | `/users/me/password` | Yes | Change password (`current_password`, `new_password`) |
+
+______________________________________________________________________
+
+## Agents (`/api/v1/agents`)
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/agents/` | Yes | List all registered agents |
+| GET | `/agents/{slug}` | Yes | Agent detail (includes instructions, system prompt, module path) |
+
+### Agent response fields
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `slug` | string | Unique identifier |
+| `name` | string | Display name |
+| `description` | string | What the agent does |
+| `capabilities` | list\[string\] | Keywords for routing |
+| `category` | string | Agent category |
+| `instructions` | string | (detail only) Agent instructions |
+| `system_prompt` | string | (detail only) Composed system prompt |
+| `module_path` | string | (detail only) Python module path |
+
+______________________________________________________________________
+
+## Teams (`/api/v1/teams`)
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/teams/` | Yes | List teams (`?enabled_only=true` to filter) |
+| POST | `/teams/` | Yes | Create team |
+| GET | `/teams/{team_id}` | Yes | Get team |
+| PATCH | `/teams/{team_id}` | Yes | Update team |
+| DELETE | `/teams/{team_id}` | Yes | Delete team (204) |
+
+### Create/update fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `name` | string | yes | Team name |
+| `slug` | string | yes (create) | Team slug |
+| `description` | string | no | Description |
+| `goal` | string | no | Team objective |
+| `agent_slugs` | list\[string\] | no | Agent slugs in team |
+| `is_enabled` | bool | no | Default `true` |
+
+______________________________________________________________________
+
+## Workflows (`/api/v1/workflows`)
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/workflows/` | Yes | List all workflows |
+| POST | `/workflows/` | Yes | Create workflow |
+| GET | `/workflows/{workflow_id}` | Yes | Get workflow |
+| PATCH | `/workflows/{workflow_id}` | Yes | Update workflow |
+| DELETE | `/workflows/{workflow_id}` | Yes | Delete workflow (204) |
+
+### Create/update fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `name` | string | yes | Workflow name |
+| `slug` | string | yes (create) | Workflow slug |
+| `description` | string | no | Description |
+| `team_id` | string | no | Associated team |
+| `trigger_event` | string | no | Event type that triggers this workflow |
+| `is_enabled` | bool | no | Default `true` |
+
+______________________________________________________________________
+
+## Tasks (`/api/v1/tasks`)
+
+Users can only access their own tasks.
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/tasks/` | Yes | List tasks (newest first) |
+| POST | `/tasks/` | Yes | Create task |
+| GET | `/tasks/{task_id}` | Yes | Get task |
+| PATCH | `/tasks/{task_id}` | Yes | Update status/output |
+| DELETE | `/tasks/{task_id}` | Yes | Delete task (204) |
+
+### Task response fields
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `id` | string | Task ID |
+| `title` | string | Task title |
+| `status` | string | `pending`, `queued`, `running`, `success`, `failure`, `cancelled`, `retrying` |
+| `input_data` | dict | Input parameters |
+| `output_data` | dict | Task output |
+| `error` | string \| null | Error message if failed |
+| `source_channel` | string \| null | Originating channel |
+| `created_at` | datetime | Creation timestamp |
+| `updated_at` | datetime | Last update timestamp |
+
+______________________________________________________________________
+
+## Events (`/api/v1/events`)
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/events/` | Yes | List events (max 200, newest first) |
+| POST | `/events/` | Yes | Create event |
+
+### Create fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `type` | string | yes | Event type |
+| `payload` | dict | no | Event data |
+| `source_channel` | string | no | Source channel |
+
+______________________________________________________________________
+
+## Prompts / Preferences (`/api/v1/prompts`)
+
+User preferences that shape LLM interactions. Valid names: `personality`, `interests`, `schedule`, `priorities`, `communication`, `home`, `work`, `style`.
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/prompts/definitions` | Yes | List all preference definitions with labels and placeholders |
+| GET | `/prompts/` | Yes | List user's preferences (auto-seeds defaults if empty) |
+| GET | `/prompts/{name}` | Yes | Get specific preference |
+| PUT | `/prompts/{name}` | Yes | Create or update preference (max 10,000 chars) |
+| DELETE | `/prompts/{name}` | Yes | Delete preference |
+| POST | `/prompts/reset` | Yes | Reset all preferences to defaults |
+
+______________________________________________________________________
+
+## Schedules (`/api/v1/schedules`)
+
+Cron-based scheduled jobs. Users can only access their own schedules.
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/schedules/` | Yes | List schedules |
+| POST | `/schedules/` | Yes | Create schedule |
+| GET | `/schedules/{schedule_id}` | Yes | Get schedule |
+| PATCH | `/schedules/{schedule_id}` | Yes | Update schedule |
+| DELETE | `/schedules/{schedule_id}` | Yes | Delete schedule (204) |
+| PATCH | `/schedules/{schedule_id}/toggle` | Yes | Toggle enabled/disabled |
+
+### Create/update fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `name` | string | yes | Schedule name (max 255) |
+| `description` | string | no | Description |
+| `cron_expression` | string | yes (create) | Cron expression (max 50, validated) |
+| `agent_slug` | string | no | Agent to execute |
+| `task_payload` | dict | no | Task parameters |
+| `is_enabled` | bool | no | Default `true` |
+
+### Schedule response extras
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `cron_human` | string | Human-readable cron description |
+| `last_run_at` | datetime \| null | Last execution time |
+| `next_run_at` | datetime \| null | Next scheduled execution |
+
+______________________________________________________________________
+
+## Channels (`/api/v1/channels`)
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/channels/` | Yes | List channel configurations |
+| PUT | `/channels/{channel_type}` | Yes | Create or update channel config (upsert) |
+
+### Upsert fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `type` | string | yes | Channel type identifier |
+| `is_enabled` | bool | no | Default `true` |
+| `config` | dict | no | Channel-specific configuration |
+
+______________________________________________________________________
+
+## Connections (`/api/v1/connections`)
+
+Service connections with encrypted credential storage.
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/connections/services` | Yes | List available service definitions and required fields |
+| GET | `/connections/` | Yes | List user's connections (credentials masked) |
+| GET | `/connections/{connection_id}` | Yes | Get connection (credentials masked) |
+| POST | `/connections/` | Yes | Create connection |
+| PATCH | `/connections/{connection_id}` | Yes | Update credentials or display name |
+| DELETE | `/connections/{connection_id}` | Yes | Delete connection (204) |
+| POST | `/connections/{connection_id}/test` | Yes | Test connection validity against service endpoint |
+
+### Create fields
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `service_type` | string | yes | Service type key |
+| `credentials` | dict | yes | Service credentials (encrypted at rest) |
+| `display_name` | string | no | Custom display name |
+
+### Test response
+
+```json
+{
+  "success": true,
+  "message": "Connection is working",
+  "status": "CONNECTED"
+}
+```
+
+______________________________________________________________________
+
+## Conversations (`/api/v1/conversations`)
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/conversations/` | Yes | List conversations (paginated: `?limit=20&offset=0`) |
+| POST | `/conversations/` | Yes | Create conversation (optional `title`, defaults to "New Chat") |
+| GET | `/conversations/{conversation_id}` | Yes | Get conversation |
+| GET | `/conversations/{conversation_id}/messages` | Yes | Get all messages (oldest first) |
+| PATCH | `/conversations/{conversation_id}` | Yes | Update title |
+| DELETE | `/conversations/{conversation_id}` | Yes | Delete conversation and messages (204) |
+
+### Pagination response
+
+```json
+{
+  "items": [...],
+  "total": 42,
+  "has_more": true
+}
+```
+
+### Message fields
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `id` | string | Message ID |
+| `conversation_id` | string | Parent conversation |
+| `role` | string | `USER` or `ASSISTANT` |
+| `content` | string | Message content (may contain markdown) |
+| `agent_slug` | string \| null | Agent that produced the response |
+| `created_at` | datetime | Timestamp |
+
+______________________________________________________________________
+
+## Chat WebSocket (`/api/v1/chat/ws`)
+
+Real-time chat with LLM-powered responses and agent task dispatch.
+
+**Connect:** `ws://localhost:8000/api/v1/chat/ws?token=<jwt>&conversation_id=<optional>`
+
+### Send message
+
+```json
+{"content": "What's the weather in NYC?"}
+```
+
+Plain text (non-JSON) is also accepted as message content.
+
+### Receive response
+
+```json
+{
+  "content": "Let me check the weather for you...",
+  "role": "assistant",
+  "conversation_id": "conv-id-123",
+  "task_dispatched": true
+}
+```
+
+### Heartbeat
+
+Send `{"type": "ping"}`, receive `{"type": "pong"}`.
+
+### Agent routing
+
+- Use `@agent-slug` in your message to route to a specific agent (e.g., `@github list my PRs`)
+- Use `@team-slug` to route to a team
+- Without @-mentions, Angie decides whether to answer directly or dispatch to an agent
+
+### Task results
+
+When a dispatched task completes, the result is pushed to the WebSocket via Redis pub/sub.
+
+______________________________________________________________________
+
+## Media (`/api/v1/media`)
+
+Serves files generated by agents (screenshots, images).
+
+| Method | Path | Auth | Description |
+| ------ | ---- | ---- | ----------- |
+| GET | `/media/{filename}?token=<jwt>` | Yes (query param) | Serve media file |
+
+Auth is via query parameter so URLs work in `<img src="...">` tags.
+Path traversal is blocked — only bare filenames are accepted.
+
+______________________________________________________________________
+
+## Quick Reference
+
+| Method | Path | Auth | Status |
+| ------ | ---- | ---- | ------ |
+| GET | `/health` | No | 200 |
+| GET | `/api/v1/health` | No | 200 |
+| POST | `/api/v1/auth/register` | No | 201 |
+| POST | `/api/v1/auth/token` | No | 200 |
+| GET | `/api/v1/users/me` | Yes | 200 |
+| PATCH | `/api/v1/users/me` | Yes | 200 |
+| POST | `/api/v1/users/me/password` | Yes | 200 |
+| GET | `/api/v1/agents/` | Yes | 200 |
+| GET | `/api/v1/agents/{slug}` | Yes | 200 |
+| GET | `/api/v1/teams/` | Yes | 200 |
+| POST | `/api/v1/teams/` | Yes | 201 |
+| GET | `/api/v1/teams/{team_id}` | Yes | 200 |
+| PATCH | `/api/v1/teams/{team_id}` | Yes | 200 |
+| DELETE | `/api/v1/teams/{team_id}` | Yes | 204 |
+| GET | `/api/v1/workflows/` | Yes | 200 |
+| POST | `/api/v1/workflows/` | Yes | 201 |
+| GET | `/api/v1/workflows/{workflow_id}` | Yes | 200 |
+| PATCH | `/api/v1/workflows/{workflow_id}` | Yes | 200 |
+| DELETE | `/api/v1/workflows/{workflow_id}` | Yes | 204 |
+| GET | `/api/v1/tasks/` | Yes | 200 |
+| POST | `/api/v1/tasks/` | Yes | 201 |
+| GET | `/api/v1/tasks/{task_id}` | Yes | 200 |
+| PATCH | `/api/v1/tasks/{task_id}` | Yes | 200 |
+| DELETE | `/api/v1/tasks/{task_id}` | Yes | 204 |
+| GET | `/api/v1/events/` | Yes | 200 |
+| POST | `/api/v1/events/` | Yes | 201 |
+| GET | `/api/v1/prompts/definitions` | Yes | 200 |
+| GET | `/api/v1/prompts/` | Yes | 200 |
+| GET | `/api/v1/prompts/{name}` | Yes | 200 |
+| PUT | `/api/v1/prompts/{name}` | Yes | 200 |
+| DELETE | `/api/v1/prompts/{name}` | Yes | 200 |
+| POST | `/api/v1/prompts/reset` | Yes | 200 |
+| GET | `/api/v1/schedules/` | Yes | 200 |
+| POST | `/api/v1/schedules/` | Yes | 201 |
+| GET | `/api/v1/schedules/{schedule_id}` | Yes | 200 |
+| PATCH | `/api/v1/schedules/{schedule_id}` | Yes | 200 |
+| DELETE | `/api/v1/schedules/{schedule_id}` | Yes | 204 |
+| PATCH | `/api/v1/schedules/{schedule_id}/toggle` | Yes | 200 |
+| GET | `/api/v1/channels/` | Yes | 200 |
+| PUT | `/api/v1/channels/{channel_type}` | Yes | 200 |
+| GET | `/api/v1/connections/services` | Yes | 200 |
+| GET | `/api/v1/connections/` | Yes | 200 |
+| GET | `/api/v1/connections/{connection_id}` | Yes | 200 |
+| POST | `/api/v1/connections/` | Yes | 201 |
+| PATCH | `/api/v1/connections/{connection_id}` | Yes | 200 |
+| DELETE | `/api/v1/connections/{connection_id}` | Yes | 204 |
+| POST | `/api/v1/connections/{connection_id}/test` | Yes | 200 |
+| GET | `/api/v1/conversations/` | Yes | 200 |
+| POST | `/api/v1/conversations/` | Yes | 201 |
+| GET | `/api/v1/conversations/{conversation_id}` | Yes | 200 |
+| GET | `/api/v1/conversations/{conversation_id}/messages` | Yes | 200 |
+| PATCH | `/api/v1/conversations/{conversation_id}` | Yes | 200 |
+| DELETE | `/api/v1/conversations/{conversation_id}` | Yes | 204 |
+| WS | `/api/v1/chat/ws` | Yes (query) | - |
+| GET | `/api/v1/media/{filename}` | Yes (query) | 200 |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -217,10 +217,12 @@ Cron-based scheduled jobs. Users can only access their own schedules.
 | ----- | ---- | -------- | ----------- |
 | `name` | string | yes | Schedule name (max 255) |
 | `description` | string | no | Description |
-| `cron_expression` | string | yes (create) | Cron expression (max 50, validated) |
+| `cron_expression` | string | yes (create) | Cron expression (max 50, validated). Supports standard 5-field cron syntax or `@once` for a one-time run. |
+| `next_run_at` | datetime | yes (create, when `cron_expression` is `@once`) | First/only execution time for `@once` schedules (ISO 8601, UTC). Required when using `@once`. |
 | `agent_slug` | string | no | Agent to execute |
 | `task_payload` | dict | no | Task parameters |
 | `is_enabled` | bool | no | Default `true` |
+| `conversation_id` | string | no | Conversation to deliver results to (web chat). |
 
 ### Schedule response extras
 

--- a/src/angie/agents/base.py
+++ b/src/angie/agents/base.py
@@ -119,6 +119,7 @@ class BaseAgent(ABC):
         title: str,
         intent: str,
         agent_slug: str | None = None,
+        conversation_id: str | None = None,
     ) -> str | None:
         """Schedule a follow-up task to run after a delay.
 
@@ -146,6 +147,7 @@ class BaseAgent(ABC):
                     task_payload={"intent": intent, "title": title},
                     is_enabled=True,
                     next_run_at=run_at,
+                    conversation_id=conversation_id,
                 )
                 session.add(job)
                 await session.commit()

--- a/src/angie/agents/base.py
+++ b/src/angie/agents/base.py
@@ -230,10 +230,12 @@ class BaseAgent(ABC):
                 result = await session.execute(
                     select(ChatMessage)
                     .where(ChatMessage.conversation_id == conversation_id)
-                    .order_by(ChatMessage.created_at.asc())
+                    .order_by(ChatMessage.created_at.desc())
                     .limit(limit)
                 )
-                messages = result.scalars().all()
+                # Fetch newest-first so LIMIT keeps recent messages,
+                # then reverse to return them in chronological (oldest→newest) order.
+                messages = list(reversed(result.scalars().all()))
                 return [
                     {
                         "role": msg.role.value,

--- a/src/angie/agents/dev/github.py
+++ b/src/angie/agents/dev/github.py
@@ -311,7 +311,13 @@ class GitHubAgent(BaseAgent):
             from angie.llm import get_llm_model
 
             intent = self._extract_intent(task, fallback="list my repositories")
-            result = await self._get_agent().run(intent, model=get_llm_model(), deps=g)
+            conversation_id = task.get("input_data", {}).get("conversation_id")
+            if conversation_id:
+                history = await self.get_conversation_history(conversation_id)
+                prompt = self._build_context_prompt(intent, history)
+            else:
+                prompt = intent
+            result = await self._get_agent().run(prompt, model=get_llm_model(), deps=g)
             return {"summary": str(result.output)}
         except Exception as exc:  # noqa: BLE001
             self.logger.exception("GitHubAgent error")

--- a/src/angie/agents/dev/software_dev.py
+++ b/src/angie/agents/dev/software_dev.py
@@ -532,6 +532,11 @@ class SoftwareDeveloperAgent(BaseAgent):
             else:
                 prompt = intent
 
+            conversation_id = task.get("input_data", {}).get("conversation_id")
+            if conversation_id:
+                history = await self.get_conversation_history(conversation_id)
+                prompt = self._build_context_prompt(prompt, history)
+
             result = await self._get_agent().run(prompt, model=get_llm_model(), deps=deps)
             summary = str(result.output)
 

--- a/src/angie/agents/lifestyle/weather.py
+++ b/src/angie/agents/lifestyle/weather.py
@@ -266,8 +266,14 @@ class WeatherAgent(BaseAgent):
             from angie.llm import get_llm_model
 
             intent = self._extract_intent(task, fallback="what's the weather like?")
+            conversation_id = task.get("input_data", {}).get("conversation_id")
+            if conversation_id:
+                history = await self.get_conversation_history(conversation_id)
+                prompt = self._build_context_prompt(intent, history)
+            else:
+                prompt = intent
             deps: dict[str, Any] = {"api_key": api_key}
-            result = await self._get_agent().run(intent, model=get_llm_model(), deps=deps)
+            result = await self._get_agent().run(prompt, model=get_llm_model(), deps=deps)
             return {"summary": str(result.output)}
 
         except Exception as exc:  # noqa: BLE001

--- a/src/angie/agents/productivity/web.py
+++ b/src/angie/agents/productivity/web.py
@@ -274,7 +274,13 @@ class WebAgent(BaseAgent):
             from angie.llm import get_llm_model
 
             intent = self._extract_intent(task, fallback="browse the web")
-            result = await self._get_agent().run(intent, model=get_llm_model(), deps={})
+            conversation_id = task.get("input_data", {}).get("conversation_id")
+            if conversation_id:
+                history = await self.get_conversation_history(conversation_id)
+                prompt = self._build_context_prompt(intent, history)
+            else:
+                prompt = intent
+            result = await self._get_agent().run(prompt, model=get_llm_model(), deps={})
             return {"summary": str(result.output)}
         except Exception as exc:  # noqa: BLE001
             self.logger.exception("WebAgent error")

--- a/src/angie/agents/system/cron.py
+++ b/src/angie/agents/system/cron.py
@@ -128,8 +128,21 @@ class CronAgent(BaseAgent):
         from angie.llm import get_llm_model
 
         intent = self._extract_intent(task, fallback="list scheduled tasks")
+        input_data = task.get("input_data", {})
         user_id = task.get("user_id", "")
-        conversation_id = task.get("input_data", {}).get("conversation_id", "")
+        conversation_id = input_data.get("conversation_id", "")
+
+        job_id = input_data.get("job_id")
+        if job_id:
+            task_name = input_data.get("task_name", "")
+            intent = (
+                f"A scheduled cron job just fired (job_id={job_id}). "
+                f"The job name is '{task_name}'. "
+                f"Your task: {intent}. "
+                f"Execute the described task. If this is a reminder or notification, "
+                f"acknowledge it clearly and provide any helpful context. "
+                f"If the task involves listing or managing schedules, use your tools."
+            )
         self.logger.info("CronAgent intent=%r user_id=%s", intent, user_id)
         try:
             # Build a fresh agent with user_id baked into tool closures

--- a/src/angie/api/routers/chat.py
+++ b/src/angie/api/routers/chat.py
@@ -86,6 +86,9 @@ def _build_agents_catalog(team_map: dict[str, list[str]] | None = None) -> str:
         "When a message contains a team @-mention, use that team's slug as the "
         "`team_slug` parameter in `dispatch_task`. "
         "Strip the @-mention from the intent text.\n\n"
+        "A message may contain **multiple** @-mentions. When it does, dispatch a separate "
+        "task for each mentioned agent/team, each with its own intent extracted from the "
+        "message.\n\n"
         "**IMPORTANT:** Always preserve any URLs from the user's message verbatim in the "
         "`intent` parameter. Do NOT rephrase or omit URLs — pass them exactly as written."
     )
@@ -111,12 +114,14 @@ def _build_agents_catalog(team_map: dict[str, list[str]] | None = None) -> str:
 _MENTION_PATTERN = re.compile(r"(?:^|(?<=\s))@([a-z][a-z0-9_-]*)", re.IGNORECASE)
 
 
-def _extract_mention(
+def _extract_mentions(
     message: str, team_slugs: set[str] | None = None
-) -> tuple[str | None, str | None, str]:
-    """Extract @mention from message.
+) -> tuple[list[tuple[str, str]], str]:
+    """Extract all @mentions from a message.
 
-    Returns (slug, kind, cleaned_message) where kind is "agent", "team", or None.
+    Returns ([(slug, kind), ...], cleaned_message) where kind is "agent" or "team".
+    Processes matches in reverse order to preserve string offsets during removal.
+    Deduplicates slugs (same agent mentioned twice -> one entry).
     """
     from angie.agents.registry import get_registry
 
@@ -124,15 +129,86 @@ def _extract_mention(
     agent_slugs = {a.slug for a in registry.list_all()}
     _team_slugs = team_slugs or set()
 
-    match = _MENTION_PATTERN.search(message)
-    if match:
+    matches = list(_MENTION_PATTERN.finditer(message))
+    if not matches:
+        return [], message
+
+    mentions: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    cleaned = message
+
+    # Process in reverse order so earlier indices stay valid after removal
+    for match in reversed(matches):
         slug = match.group(1).lower()
-        cleaned = (message[: match.start()] + message[match.end() :]).strip()
+        kind: str | None = None
         if slug in agent_slugs:
-            return slug, "agent", cleaned
-        if slug in _team_slugs:
-            return slug, "team", cleaned
+            kind = "agent"
+        elif slug in _team_slugs:
+            kind = "team"
+
+        if kind and slug not in seen:
+            # Insert at front since we're iterating in reverse
+            mentions.insert(0, (slug, kind))
+            seen.add(slug)
+
+        if kind:
+            cleaned = cleaned[: match.start()] + cleaned[match.end() :]
+
+    return mentions, cleaned.strip()
+
+
+def _extract_mention(
+    message: str, team_slugs: set[str] | None = None
+) -> tuple[str | None, str | None, str]:
+    """Extract first @mention from message (backward-compat wrapper).
+
+    Returns (slug, kind, cleaned_message) where kind is "agent", "team", or None.
+    """
+    mentions, cleaned = _extract_mentions(message, team_slugs)
+    if mentions:
+        slug, kind = mentions[0]
+        return slug, kind, cleaned
     return None, None, message
+
+
+async def _notify_subscribed_agents(
+    *,
+    conversation_id: str,
+    user_id: str,
+    user_message: str,
+    mentioned_slugs: set[str],
+) -> None:
+    """Dispatch lightweight auto_notify tasks to subscribed agents.
+
+    Only agents NOT already @-mentioned are notified. Each agent is checked
+    for cooldown to prevent rapid-fire responses.
+    """
+    from angie.core.conv_subscriptions import (
+        check_cooldown,
+        get_subscribed_agents,
+        set_cooldown,
+    )
+    from angie.core.intent import dispatch_task
+
+    subscribed = await get_subscribed_agents(conversation_id)
+    # Exclude agents that were explicitly @-mentioned (they get direct tasks)
+    candidates = subscribed - mentioned_slugs
+    if not candidates:
+        return
+
+    for agent_slug in candidates:
+        if await check_cooldown(conversation_id, agent_slug):
+            continue
+
+        await set_cooldown(conversation_id, agent_slug)
+        await dispatch_task(
+            title=f"Auto-notify {agent_slug}",
+            intent=user_message,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            agent_slug=agent_slug,
+            parameters={"auto_notify": True},
+        )
 
 
 def _build_chat_agent(
@@ -367,21 +443,27 @@ async def chat_ws(websocket: WebSocket, token: str, conversation_id: str | None 
                 except Exception as exc:
                     logger.warning("Could not persist user message: %s", exc)
 
-            # Extract @-mention if present (agent or team)
-            mentioned_slug, mention_kind, cleaned_message = _extract_mention(
-                user_message, team_slug_set
-            )
+            # Extract @-mentions if present (agents or teams)
+            mentions, cleaned_message = _extract_mentions(user_message, team_slug_set)
             llm_message = user_message
-            if mentioned_slug and mention_kind == "agent":
-                llm_message = (
-                    f"[The user @-mentioned the `{mentioned_slug}` agent. "
-                    f"Use agent_slug='{mentioned_slug}' when dispatching.]\n\n{cleaned_message}"
-                )
-            elif mentioned_slug and mention_kind == "team":
-                llm_message = (
-                    f"[The user @-mentioned the `{mentioned_slug}` team. "
-                    f"Use team_slug='{mentioned_slug}' when dispatching.]\n\n{cleaned_message}"
-                )
+            if mentions:
+                annotation_lines = ["[The user @-mentioned the following:"]
+                for slug, kind in mentions:
+                    if kind == "agent":
+                        annotation_lines.append(
+                            f"- `@{slug}` (agent): Use agent_slug='{slug}' when dispatching."
+                        )
+                    elif kind == "team":
+                        annotation_lines.append(
+                            f"- `@{slug}` (team): Use team_slug='{slug}' when dispatching."
+                        )
+                if len(mentions) > 1:
+                    annotation_lines.append(
+                        "Dispatch a separate task for each mention with the appropriate slug.]"
+                    )
+                else:
+                    annotation_lines.append("]")
+                llm_message = "\n".join(annotation_lines) + f"\n\n{cleaned_message}"
 
             task_dispatched = False
             if agent is None:
@@ -420,6 +502,18 @@ async def chat_ws(websocket: WebSocket, token: str, conversation_id: str | None 
                         await session.commit()
                 except Exception as exc:
                     logger.warning("Could not persist assistant message: %s", exc)
+
+            # Notify subscribed agents (those not explicitly @-mentioned)
+            if conversation_id:
+                try:
+                    await _notify_subscribed_agents(
+                        conversation_id=conversation_id,
+                        user_id=user_id,
+                        user_message=user_message,
+                        mentioned_slugs={slug for slug, _ in mentions},
+                    )
+                except Exception as exc:
+                    logger.debug("Subscription notification failed: %s", exc)
 
             response = {"content": reply, "role": "assistant"}
             if conversation_id:

--- a/src/angie/api/routers/prompts.py
+++ b/src/angie/api/routers/prompts.py
@@ -135,7 +135,7 @@ async def _seed_defaults(user_id: str, session: AsyncSession) -> list[Prompt]:
 
 
 @router.get("/definitions", response_model=list[PreferenceDefinition])
-async def get_definitions():
+async def get_definitions(_: User = Depends(get_current_user)):
     """Return the preference category definitions."""
     return PREFERENCE_DEFINITIONS
 

--- a/src/angie/core/conv_subscriptions.py
+++ b/src/angie/core/conv_subscriptions.py
@@ -1,0 +1,90 @@
+"""Conversation subscription system — tracks which agents are active in a conversation."""
+
+from __future__ import annotations
+
+import logging
+
+from angie.cache.redis import get_redis
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "angie:conv_subs"
+_COOLDOWN_PREFIX = "angie:auto_cooldown"
+_SUB_TTL = 86400  # 24 hours
+_COOLDOWN_TTL = 30  # 30 seconds
+_MAX_SUBS_PER_CONVERSATION = 5
+
+
+async def subscribe_agent(conversation_id: str, agent_slug: str) -> bool:
+    """Add an agent to a conversation's subscriber set.
+
+    Returns True if the agent was added, False if the cap was reached.
+    """
+    key = f"{_KEY_PREFIX}:{conversation_id}"
+    try:
+        client = get_redis()
+        current_size = await client.scard(key)
+        if current_size >= _MAX_SUBS_PER_CONVERSATION:
+            # Check if already subscribed (doesn't count against cap)
+            if await client.sismember(key, agent_slug):
+                return True
+            logger.debug(
+                "Subscription cap reached for conversation %s (%d/%d)",
+                conversation_id,
+                current_size,
+                _MAX_SUBS_PER_CONVERSATION,
+            )
+            return False
+        await client.sadd(key, agent_slug)
+        await client.expire(key, _SUB_TTL)
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Failed to subscribe agent %s to conversation %s: %s", agent_slug, conversation_id, exc
+        )
+        return False
+
+
+async def unsubscribe_agent(conversation_id: str, agent_slug: str) -> None:
+    """Remove an agent from a conversation's subscriber set."""
+    key = f"{_KEY_PREFIX}:{conversation_id}"
+    try:
+        client = get_redis()
+        await client.srem(key, agent_slug)
+    except Exception as exc:
+        logger.warning("Failed to unsubscribe agent %s: %s", agent_slug, exc)
+
+
+async def get_subscribed_agents(conversation_id: str) -> set[str]:
+    """Return the set of agent slugs subscribed to a conversation."""
+    key = f"{_KEY_PREFIX}:{conversation_id}"
+    try:
+        client = get_redis()
+        return await client.smembers(key)
+    except Exception as exc:
+        logger.warning("Failed to get subscribed agents: %s", exc)
+        return set()
+
+
+async def check_cooldown(conversation_id: str, agent_slug: str) -> bool:
+    """Check if an agent is in cooldown for auto-responses in a conversation.
+
+    Returns True if the agent is in cooldown (should NOT respond).
+    """
+    key = f"{_COOLDOWN_PREFIX}:{conversation_id}:{agent_slug}"
+    try:
+        client = get_redis()
+        return await client.exists(key) > 0
+    except Exception as exc:
+        logger.warning("Failed to check cooldown: %s", exc)
+        return True  # Fail safe: assume cooldown
+
+
+async def set_cooldown(conversation_id: str, agent_slug: str) -> None:
+    """Set a cooldown for an agent's auto-responses in a conversation."""
+    key = f"{_COOLDOWN_PREFIX}:{conversation_id}:{agent_slug}"
+    try:
+        client = get_redis()
+        await client.setex(key, _COOLDOWN_TTL, "1")
+    except Exception as exc:
+        logger.warning("Failed to set cooldown: %s", exc)

--- a/src/angie/core/cron.py
+++ b/src/angie/core/cron.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.date import DateTrigger
 
 from angie.core.events import AngieEvent, router
 from angie.models.event import EventType
@@ -20,7 +21,9 @@ _FIELD_NAMES = ("minute", "hour", "day-of-month", "month", "day-of-week")
 
 
 def validate_cron_expression(expression: str) -> tuple[bool, str]:
-    """Validate a 5-part cron expression. Returns (is_valid, error_message)."""
+    """Validate a 5-part cron expression or '@once'. Returns (is_valid, error_message)."""
+    if expression.strip() == "@once":
+        return True, ""
     parts = expression.strip().split()
     if len(parts) != 5:
         return False, f"Expected 5 fields (minute hour day month weekday), got {len(parts)}"
@@ -40,6 +43,8 @@ def validate_cron_expression(expression: str) -> tuple[bool, str]:
 
 def cron_to_human(expression: str) -> str:
     """Convert a 5-part cron expression to a human-readable description."""
+    if expression.strip() == "@once":
+        return "One-time"
     parts = expression.strip().split()
     if len(parts) != 5:
         return expression
@@ -177,52 +182,76 @@ class CronEngine:
 
     def _register_job(self, job_record: Any) -> None:
         """Register a single ScheduledJob with APScheduler."""
-        parts = job_record.cron_expression.split()
-        if len(parts) != 5:
-            logger.warning(
-                "Invalid cron expression for job %s: %s", job_record.id, job_record.cron_expression
-            )
-            return
-
-        minute, hour, day, month, day_of_week = parts
-
         job_id = job_record.id
-        try:
-            trigger = CronTrigger(
-                minute=minute,
-                hour=hour,
-                day=day,
-                month=month,
-                day_of_week=day_of_week,
-                timezone="UTC",
-            )
-        except (ValueError, KeyError):
-            logger.exception(
-                "Invalid cron trigger for job %s (%s): %s",
-                job_record.name,
-                job_id,
-                job_record.cron_expression,
-            )
-            return
+        is_once = job_record.cron_expression.strip() == "@once"
+
+        if is_once:
+            run_at = job_record.next_run_at
+            if run_at is None:
+                logger.warning("@once job %s has no next_run_at, skipping", job_id)
+                return
+            # Skip if the fire time has already passed
+            now = datetime.now(UTC)
+            if run_at.tzinfo is None:
+                run_at = run_at.replace(tzinfo=UTC)
+            if run_at <= now:
+                logger.info("@once job %s fire time already passed, disabling", job_id)
+                asyncio.create_task(self._disable_once_job(job_id))
+                return
+            trigger = DateTrigger(run_date=run_at, timezone="UTC")
+        else:
+            parts = job_record.cron_expression.split()
+            if len(parts) != 5:
+                logger.warning(
+                    "Invalid cron expression for job %s: %s",
+                    job_record.id,
+                    job_record.cron_expression,
+                )
+                return
+
+            minute, hour, day, month, day_of_week = parts
+            try:
+                trigger = CronTrigger(
+                    minute=minute,
+                    hour=hour,
+                    day=day,
+                    month=month,
+                    day_of_week=day_of_week,
+                    timezone="UTC",
+                )
+            except (ValueError, KeyError):
+                logger.exception(
+                    "Invalid cron trigger for job %s (%s): %s",
+                    job_record.name,
+                    job_id,
+                    job_record.cron_expression,
+                )
+                return
 
         user_id = job_record.user_id
         agent_slug = job_record.agent_slug
+        conversation_id = job_record.conversation_id
         payload = {
             "task_name": job_record.name,
             "job_id": job_id,
             "agent_slug": agent_slug,
+            "intent": job_record.description or job_record.name,
             **(job_record.task_payload or {}),
         }
+        if conversation_id:
+            payload["conversation_id"] = conversation_id
 
         async def _fire() -> None:
             event = AngieEvent(
                 type=EventType.CRON,
                 user_id=user_id,
                 payload=payload,
-                source_channel="cron",
+                source_channel="web",
             )
             await router.dispatch(event)
             await self._update_last_run(job_id)
+            if is_once:
+                await self._disable_once_job(job_id)
 
         job = self.scheduler.add_job(
             _fire,
@@ -290,6 +319,24 @@ class CronEngine:
                 await session.commit()
         except Exception:  # noqa: BLE001
             logger.exception("Failed to update last_run_at for job %s", job_id)
+
+    async def _disable_once_job(self, job_id: str) -> None:
+        """Disable a @once job after it fires (or if its time has passed)."""
+        from sqlalchemy import update
+
+        from angie.db.session import get_session_factory
+        from angie.models.schedule import ScheduledJob
+
+        try:
+            async with get_session_factory()() as session:
+                await session.execute(
+                    update(ScheduledJob).where(ScheduledJob.id == job_id).values(is_enabled=False)
+                )
+                await session.commit()
+            self._jobs.pop(job_id, None)
+            logger.info("Disabled @once job %s after firing", job_id)
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to disable @once job %s", job_id)
 
     # ------------------------------------------------------------------
     # Direct management (used by daemon loop event handler)

--- a/src/angie/core/intent.py
+++ b/src/angie/core/intent.py
@@ -148,6 +148,15 @@ async def dispatch_task(
             except Exception as exc:
                 logger.warning("Failed to update task with celery ID: %s", exc)
 
+        # Auto-subscribe the agent to the conversation for future awareness
+        if conversation_id and resolved_agent:
+            try:
+                from angie.core.conv_subscriptions import subscribe_agent
+
+                await subscribe_agent(conversation_id, resolved_agent)
+            except Exception as exc:
+                logger.debug("Failed to auto-subscribe agent: %s", exc)
+
         return {
             "dispatched": True,
             "task_id": task_record_id or task.id,

--- a/src/angie/core/loop.py
+++ b/src/angie/core/loop.py
@@ -79,9 +79,13 @@ class AngieLoop:
             if event.type not in dispatchable:
                 return
             # Use message text as task title for channel messages
+            agent_slug = None
             if event.type == EventType.CHANNEL_MESSAGE:
                 text = event.payload.get("text", "")[:120]
                 title = text if text else "Channel message"
+            elif event.type == EventType.CRON:
+                title = event.payload.get("task_name") or "Cron task"
+                agent_slug = event.payload.get("agent_slug")
             else:
                 title = f"Task from {event.type.value} event"
             from angie.core.tasks import AngieTask
@@ -90,6 +94,7 @@ class AngieLoop:
                 title=title,
                 user_id=event.user_id or "system",
                 input_data=event.payload,
+                agent_slug=agent_slug,
                 source_event_id=event.id,
                 source_channel=event.source_channel,
             )

--- a/src/angie/models/schedule.py
+++ b/src/angie/models/schedule.py
@@ -35,6 +35,9 @@ class ScheduledJob(Base, TimestampMixin):
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
     last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     next_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    conversation_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True
+    )
 
     user: Mapped[User] = relationship(back_populates="scheduled_jobs")  # noqa: F821
 

--- a/src/angie/queue/workers.py
+++ b/src/angie/queue/workers.py
@@ -192,10 +192,10 @@ async def _run_task(task_dict: dict[str, Any]) -> dict[str, Any]:
         or "Task complete."
     )
 
-    # Skip delivery for auto_notify tasks that returned empty/None summaries
+    # Skip delivery for auto_notify tasks that returned empty/None summaries.
+    # Note: task DB state was already persisted above (line with _update_task_in_db),
+    # so no second write is needed here.
     if is_auto_notify and (not summary or summary == "Task complete."):
-        if task_id:
-            await _update_task_in_db(task_id, "success", result, None)
         return {
             "status": "success",
             "result": result,

--- a/tests/unit/test_agent_context.py
+++ b/tests/unit/test_agent_context.py
@@ -127,8 +127,10 @@ async def test_get_conversation_history_returns_messages(mock_pm, mock_gs):
     mock_msg2.content = "world"
     mock_msg2.agent_slug = "weather"
 
+    # The query now uses DESC order so the DB returns newest-first.
+    # Simulate that here: mock_msg2 (assistant, newer) comes before mock_msg1 (user, older).
     mock_result = MagicMock()
-    mock_result.scalars.return_value.all.return_value = [mock_msg1, mock_msg2]
+    mock_result.scalars.return_value.all.return_value = [mock_msg2, mock_msg1]
 
     mock_session = AsyncMock()
     mock_session.execute = AsyncMock(return_value=mock_result)

--- a/tests/unit/test_agent_context.py
+++ b/tests/unit/test_agent_context.py
@@ -1,0 +1,172 @@
+"""Tests for BaseAgent conversation context methods."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
+os.environ.setdefault("DB_PASSWORD", "test-password")
+
+
+# ── _build_context_prompt tests ───────────────────────────────────────────────
+
+
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+def test_build_context_prompt_with_history(mock_pm, mock_gs):
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class DummyAgent(BaseAgent):
+        name = "Dummy"
+        slug = "dummy"
+        description = "test"
+
+        async def execute(self, task):
+            return {}
+
+    agent = DummyAgent()
+    history = [
+        {"role": "user", "content": "What's the weather?", "agent_slug": ""},
+        {"role": "assistant", "content": "It's 72°F and sunny.", "agent_slug": "weather"},
+        {"role": "user", "content": "Now check my GitHub PRs", "agent_slug": ""},
+    ]
+
+    result = agent._build_context_prompt("check open PRs", history)
+
+    assert "## Conversation Context" in result
+    assert "[USER]: What's the weather?" in result
+    assert "[weather]: It's 72°F and sunny." in result
+    assert "[USER]: Now check my GitHub PRs" in result
+    assert "## Your Task" in result
+    assert "check open PRs" in result
+
+
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+def test_build_context_prompt_empty_history(mock_pm, mock_gs):
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class DummyAgent(BaseAgent):
+        name = "Dummy"
+        slug = "dummy"
+        description = "test"
+
+        async def execute(self, task):
+            return {}
+
+    agent = DummyAgent()
+    result = agent._build_context_prompt("check open PRs", [])
+
+    assert result == "check open PRs"
+
+
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+def test_build_context_prompt_assistant_no_slug(mock_pm, mock_gs):
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class DummyAgent(BaseAgent):
+        name = "Dummy"
+        slug = "dummy"
+        description = "test"
+
+        async def execute(self, task):
+            return {}
+
+    agent = DummyAgent()
+    history = [
+        {"role": "assistant", "content": "Hello!", "agent_slug": ""},
+    ]
+
+    result = agent._build_context_prompt("do something", history)
+    assert "[ASSISTANT]: Hello!" in result
+
+
+# ── get_conversation_history tests ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+async def test_get_conversation_history_returns_messages(mock_pm, mock_gs):
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class DummyAgent(BaseAgent):
+        name = "Dummy"
+        slug = "dummy"
+        description = "test"
+
+        async def execute(self, task):
+            return {}
+
+    agent = DummyAgent()
+
+    # Mock the DB query
+    mock_msg1 = MagicMock()
+    mock_msg1.role.value = "user"
+    mock_msg1.content = "hello"
+    mock_msg1.agent_slug = None
+
+    mock_msg2 = MagicMock()
+    mock_msg2.role.value = "assistant"
+    mock_msg2.content = "world"
+    mock_msg2.agent_slug = "weather"
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [mock_msg1, mock_msg2]
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    mock_factory = MagicMock()
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    mock_factory.return_value = mock_ctx
+
+    with patch("angie.db.session.get_session_factory", return_value=mock_factory):
+        history = await agent.get_conversation_history("conv-123")
+
+    assert len(history) == 2
+    assert history[0] == {"role": "user", "content": "hello", "agent_slug": ""}
+    assert history[1] == {"role": "assistant", "content": "world", "agent_slug": "weather"}
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+async def test_get_conversation_history_db_error_returns_empty(mock_pm, mock_gs):
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class DummyAgent(BaseAgent):
+        name = "Dummy"
+        slug = "dummy"
+        description = "test"
+
+        async def execute(self, task):
+            return {}
+
+    agent = DummyAgent()
+
+    with patch("angie.db.session.get_session_factory", side_effect=Exception("DB down")):
+        history = await agent.get_conversation_history("conv-123")
+
+    assert history == []

--- a/tests/unit/test_conv_subscriptions.py
+++ b/tests/unit/test_conv_subscriptions.py
@@ -1,0 +1,181 @@
+"""Tests for conversation subscription system."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-testing")
+os.environ.setdefault("DB_PASSWORD", "test-password")
+
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock async Redis client."""
+    client = AsyncMock()
+    client.scard = AsyncMock(return_value=0)
+    client.sismember = AsyncMock(return_value=False)
+    client.sadd = AsyncMock()
+    client.srem = AsyncMock()
+    client.expire = AsyncMock()
+    client.smembers = AsyncMock(return_value=set())
+    client.exists = AsyncMock(return_value=0)
+    client.setex = AsyncMock()
+    return client
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_subscribe_agent(mock_gs, mock_redis):
+    mock_gs.return_value = MagicMock()
+    with patch("angie.core.conv_subscriptions.get_redis", return_value=mock_redis):
+        from angie.core.conv_subscriptions import subscribe_agent
+
+        result = await subscribe_agent("conv-1", "weather")
+        assert result is True
+        mock_redis.sadd.assert_called_once_with("angie:conv_subs:conv-1", "weather")
+        mock_redis.expire.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_subscribe_agent_cap_reached(mock_gs, mock_redis):
+    mock_gs.return_value = MagicMock()
+    mock_redis.scard = AsyncMock(return_value=5)
+    mock_redis.sismember = AsyncMock(return_value=False)
+    with patch("angie.core.conv_subscriptions.get_redis", return_value=mock_redis):
+        from angie.core.conv_subscriptions import subscribe_agent
+
+        result = await subscribe_agent("conv-1", "new-agent")
+        assert result is False
+        mock_redis.sadd.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_subscribe_agent_already_subscribed_at_cap(mock_gs, mock_redis):
+    mock_gs.return_value = MagicMock()
+    mock_redis.scard = AsyncMock(return_value=5)
+    mock_redis.sismember = AsyncMock(return_value=True)
+    with patch("angie.core.conv_subscriptions.get_redis", return_value=mock_redis):
+        from angie.core.conv_subscriptions import subscribe_agent
+
+        result = await subscribe_agent("conv-1", "weather")
+        assert result is True
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_unsubscribe_agent(mock_gs, mock_redis):
+    mock_gs.return_value = MagicMock()
+    with patch("angie.core.conv_subscriptions.get_redis", return_value=mock_redis):
+        from angie.core.conv_subscriptions import unsubscribe_agent
+
+        await unsubscribe_agent("conv-1", "weather")
+        mock_redis.srem.assert_called_once_with("angie:conv_subs:conv-1", "weather")
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_get_subscribed_agents(mock_gs, mock_redis):
+    mock_gs.return_value = MagicMock()
+    mock_redis.smembers = AsyncMock(return_value={"weather", "github"})
+    with patch("angie.core.conv_subscriptions.get_redis", return_value=mock_redis):
+        from angie.core.conv_subscriptions import get_subscribed_agents
+
+        result = await get_subscribed_agents("conv-1")
+        assert result == {"weather", "github"}
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_get_subscribed_agents_redis_error(mock_gs, mock_redis):
+    mock_gs.return_value = MagicMock()
+    mock_redis.smembers = AsyncMock(side_effect=Exception("Redis down"))
+    with patch("angie.core.conv_subscriptions.get_redis", return_value=mock_redis):
+        from angie.core.conv_subscriptions import get_subscribed_agents
+
+        result = await get_subscribed_agents("conv-1")
+        assert result == set()
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_check_cooldown_not_in_cooldown(mock_gs, mock_redis):
+    mock_gs.return_value = MagicMock()
+    mock_redis.exists = AsyncMock(return_value=0)
+    with patch("angie.core.conv_subscriptions.get_redis", return_value=mock_redis):
+        from angie.core.conv_subscriptions import check_cooldown
+
+        result = await check_cooldown("conv-1", "weather")
+        assert result is False
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_check_cooldown_in_cooldown(mock_gs, mock_redis):
+    mock_gs.return_value = MagicMock()
+    mock_redis.exists = AsyncMock(return_value=1)
+    with patch("angie.core.conv_subscriptions.get_redis", return_value=mock_redis):
+        from angie.core.conv_subscriptions import check_cooldown
+
+        result = await check_cooldown("conv-1", "weather")
+        assert result is True
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_set_cooldown(mock_gs, mock_redis):
+    mock_gs.return_value = MagicMock()
+    with patch("angie.core.conv_subscriptions.get_redis", return_value=mock_redis):
+        from angie.core.conv_subscriptions import set_cooldown
+
+        await set_cooldown("conv-1", "weather")
+        mock_redis.setex.assert_called_once_with("angie:auto_cooldown:conv-1:weather", 30, "1")
+
+
+# ── should_respond tests ─────────────────────────────────────────────────────
+
+
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+def test_should_respond_auto_notify_true(mock_pm, mock_gs):
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class DummyAgent(BaseAgent):
+        name = "Dummy"
+        slug = "dummy"
+        description = "test"
+
+        async def execute(self, task):
+            return {}
+
+    agent = DummyAgent()
+    task = {"input_data": {"parameters": {"auto_notify": True}}}
+    assert agent.should_respond(task) is True
+
+
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+def test_should_respond_no_auto_notify(mock_pm, mock_gs):
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class DummyAgent(BaseAgent):
+        name = "Dummy"
+        slug = "dummy"
+        description = "test"
+
+        async def execute(self, task):
+            return {}
+
+    agent = DummyAgent()
+    task = {"input_data": {"parameters": {}}}
+    assert agent.should_respond(task) is False

--- a/tests/unit/test_conv_subscriptions.py
+++ b/tests/unit/test_conv_subscriptions.py
@@ -139,9 +139,69 @@ async def test_set_cooldown(mock_gs, mock_redis):
 # ── should_respond tests ─────────────────────────────────────────────────────
 
 
+@pytest.mark.asyncio
 @patch("angie.config.get_settings")
 @patch("angie.core.prompts.get_prompt_manager")
-def test_should_respond_auto_notify_true(mock_pm, mock_gs):
+async def test_should_respond_relevant_keyword(mock_pm, mock_gs):
+    """Agent responds when the user message matches its capabilities."""
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class WeatherDummy(BaseAgent):
+        name = "Weather"
+        slug = "weather"
+        description = "test"
+        capabilities = ["weather", "forecast", "temperature"]
+
+        async def execute(self, task):
+            return {}
+
+    agent = WeatherDummy()
+    task = {
+        "input_data": {
+            "intent": "What's the weather like in NYC?",
+            "parameters": {"auto_notify": True},
+        }
+    }
+    assert await agent.should_respond(task) is True
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+async def test_should_respond_irrelevant_message(mock_pm, mock_gs):
+    """Agent declines when the user message doesn't match capabilities."""
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class WeatherDummy(BaseAgent):
+        name = "Weather"
+        slug = "weather"
+        description = "test"
+        capabilities = ["weather", "forecast", "temperature"]
+
+        async def execute(self, task):
+            return {}
+
+    agent = WeatherDummy()
+    task = {
+        "input_data": {
+            "intent": "remind me to cut the grass tomorrow",
+            "parameters": {"auto_notify": True},
+        }
+    }
+    assert await agent.should_respond(task) is False
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+async def test_should_respond_no_auto_notify(mock_pm, mock_gs):
+    """Agent declines when auto_notify is not set."""
     mock_gs.return_value = MagicMock()
     mock_pm.return_value = MagicMock()
 
@@ -151,31 +211,202 @@ def test_should_respond_auto_notify_true(mock_pm, mock_gs):
         name = "Dummy"
         slug = "dummy"
         description = "test"
+        capabilities = ["anything"]
 
         async def execute(self, task):
             return {}
 
     agent = DummyAgent()
-    task = {"input_data": {"parameters": {"auto_notify": True}}}
-    assert agent.should_respond(task) is True
+    task = {"input_data": {"intent": "anything goes", "parameters": {}}}
+    assert await agent.should_respond(task) is False
 
 
+@pytest.mark.asyncio
 @patch("angie.config.get_settings")
 @patch("angie.core.prompts.get_prompt_manager")
-def test_should_respond_no_auto_notify(mock_pm, mock_gs):
+async def test_should_respond_no_capabilities(mock_pm, mock_gs):
+    """Agent with no capabilities always declines auto_notify."""
     mock_gs.return_value = MagicMock()
     mock_pm.return_value = MagicMock()
 
     from angie.agents.base import BaseAgent
 
-    class DummyAgent(BaseAgent):
-        name = "Dummy"
-        slug = "dummy"
+    class NoCaps(BaseAgent):
+        name = "NoCaps"
+        slug = "nocaps"
         description = "test"
+        capabilities = []
 
         async def execute(self, task):
             return {}
 
-    agent = DummyAgent()
-    task = {"input_data": {"parameters": {}}}
-    assert agent.should_respond(task) is False
+    agent = NoCaps()
+    task = {
+        "input_data": {
+            "intent": "do something",
+            "parameters": {"auto_notify": True},
+        }
+    }
+    assert await agent.should_respond(task) is False
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+async def test_should_respond_context_relevance(mock_pm, mock_gs):
+    """Agent responds when recent conversation history matches capabilities."""
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class WeatherDummy(BaseAgent):
+        name = "Weather"
+        slug = "weather"
+        description = "test"
+        capabilities = ["weather", "forecast"]
+
+        async def execute(self, task):
+            return {}
+
+    agent = WeatherDummy()
+    # Current message doesn't mention weather, but recent history does
+    task = {
+        "input_data": {
+            "intent": "thanks, what about tomorrow?",
+            "conversation_id": "conv-123",
+            "parameters": {"auto_notify": True},
+        }
+    }
+    # Mock get_conversation_history to return recent weather context
+    history = [
+        {"role": "user", "content": "What's the weather forecast for NYC?", "agent_slug": ""},
+        {"role": "ASSISTANT", "content": "It's 72F and sunny.", "agent_slug": "weather"},
+    ]
+    with patch.object(
+        agent, "get_conversation_history", new_callable=AsyncMock, return_value=history
+    ):
+        assert await agent.should_respond(task) is True
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+@patch("angie.core.prompts.get_prompt_manager")
+async def test_should_respond_context_irrelevant(mock_pm, mock_gs):
+    """Agent declines when both message and history are irrelevant."""
+    mock_gs.return_value = MagicMock()
+    mock_pm.return_value = MagicMock()
+
+    from angie.agents.base import BaseAgent
+
+    class WeatherDummy(BaseAgent):
+        name = "Weather"
+        slug = "weather"
+        description = "test"
+        capabilities = ["weather", "forecast"]
+
+        async def execute(self, task):
+            return {}
+
+    agent = WeatherDummy()
+    task = {
+        "input_data": {
+            "intent": "remind me to cut the grass",
+            "conversation_id": "conv-123",
+            "parameters": {"auto_notify": True},
+        }
+    }
+    history = [
+        {"role": "user", "content": "check my github PRs", "agent_slug": ""},
+        {"role": "ASSISTANT", "content": "You have 3 open PRs.", "agent_slug": "github"},
+    ]
+    with patch.object(
+        agent, "get_conversation_history", new_callable=AsyncMock, return_value=history
+    ):
+        assert await agent.should_respond(task) is False
+
+
+# ── _notify_subscribed_agents exclusion tests ────────────────────────────────
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_notify_excludes_dispatched_agents(mock_gs):
+    """Agents dispatched via dispatch_task tool are excluded from auto-notify."""
+    mock_gs.return_value = MagicMock()
+
+    with (
+        patch(
+            "angie.core.conv_subscriptions.get_subscribed_agents",
+            new_callable=AsyncMock,
+            return_value={"github", "weather"},
+        ),
+        patch(
+            "angie.core.conv_subscriptions.check_cooldown",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "angie.core.conv_subscriptions.set_cooldown",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "angie.core.intent.dispatch_task",
+            new_callable=AsyncMock,
+        ) as mock_dispatch,
+    ):
+        from angie.api.routers.chat import _notify_subscribed_agents
+
+        # github was dispatched by the LLM, so only weather should be notified
+        await _notify_subscribed_agents(
+            conversation_id="conv-1",
+            user_id="user-1",
+            user_message="check my PRs",
+            mentioned_slugs={"github"},
+        )
+
+        # Only weather should have been dispatched (github excluded)
+        assert mock_dispatch.call_count == 1
+        dispatch_call = mock_dispatch.call_args
+        assert dispatch_call.kwargs["agent_slug"] == "weather"
+
+
+@pytest.mark.asyncio
+@patch("angie.config.get_settings")
+async def test_notify_excludes_both_mentioned_and_dispatched(mock_gs):
+    """Both @-mentioned and LLM-dispatched agents are excluded from auto-notify."""
+    mock_gs.return_value = MagicMock()
+
+    with (
+        patch(
+            "angie.core.conv_subscriptions.get_subscribed_agents",
+            new_callable=AsyncMock,
+            return_value={"github", "weather", "web"},
+        ),
+        patch(
+            "angie.core.conv_subscriptions.check_cooldown",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "angie.core.conv_subscriptions.set_cooldown",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "angie.core.intent.dispatch_task",
+            new_callable=AsyncMock,
+        ) as mock_dispatch,
+    ):
+        from angie.api.routers.chat import _notify_subscribed_agents
+
+        # github @-mentioned, web dispatched by LLM — only weather notified
+        await _notify_subscribed_agents(
+            conversation_id="conv-1",
+            user_id="user-1",
+            user_message="search the web for github alternatives",
+            mentioned_slugs={"github", "web"},
+        )
+
+        assert mock_dispatch.call_count == 1
+        dispatch_call = mock_dispatch.call_args
+        assert dispatch_call.kwargs["agent_slug"] == "weather"

--- a/tests/unit/test_cron_engine.py
+++ b/tests/unit/test_cron_engine.py
@@ -412,7 +412,7 @@ def test_register_job_includes_conversation_id():
 
 @pytest.mark.asyncio
 async def test_register_job_conversation_id_in_event():
-    """Verify the _fire coroutine includes conversation_id and uses source_channel='web'."""
+    """Verify the _fire coroutine includes conversation_id and uses source_channel='cron'."""
     from angie.core.cron import CronEngine
 
     mock_job_record = MagicMock()
@@ -451,4 +451,4 @@ async def test_register_job_conversation_id_in_event():
         mock_router.dispatch.assert_called_once()
         event = mock_router.dispatch.call_args[0][0]
         assert event.payload["conversation_id"] == "conv-1"
-        assert event.source_channel == "web"
+        assert event.source_channel == "cron"

--- a/tests/unit/test_extract_mention.py
+++ b/tests/unit/test_extract_mention.py
@@ -1,4 +1,4 @@
-"""Tests for _extract_mention in chat router."""
+"""Tests for _extract_mention and _extract_mentions in chat router."""
 
 from __future__ import annotations
 
@@ -124,3 +124,73 @@ def test_extract_mention_ignores_email(mock_gs):
         assert slug is None
         assert kind is None
         assert cleaned == "send to user@gmail.com"
+
+
+# ── _extract_mentions (plural) tests ──────────────────────────────────────────
+
+
+@patch("angie.config.get_settings")
+def test_extract_mentions_two_agents(mock_gs):
+    mock_gs.return_value = MagicMock()
+    registry = _make_mock_registry(["weather", "github"])
+    with patch("angie.agents.registry.get_registry", return_value=registry):
+        from angie.api.routers.chat import _extract_mentions
+
+        mentions, cleaned = _extract_mentions("@weather forecast for NYC @github check my PRs")
+        assert mentions == [("weather", "agent"), ("github", "agent")]
+        assert "forecast for NYC" in cleaned
+        assert "check my PRs" in cleaned
+        assert "@weather" not in cleaned
+        assert "@github" not in cleaned
+
+
+@patch("angie.config.get_settings")
+def test_extract_mentions_agent_and_team(mock_gs):
+    mock_gs.return_value = MagicMock()
+    registry = _make_mock_registry(["weather"])
+    with patch("angie.agents.registry.get_registry", return_value=registry):
+        from angie.api.routers.chat import _extract_mentions
+
+        mentions, cleaned = _extract_mentions(
+            "@weather forecast @media-team play music", team_slugs={"media-team"}
+        )
+        assert mentions == [("weather", "agent"), ("media-team", "team")]
+        assert "@weather" not in cleaned
+        assert "@media-team" not in cleaned
+
+
+@patch("angie.config.get_settings")
+def test_extract_mentions_dedup(mock_gs):
+    mock_gs.return_value = MagicMock()
+    registry = _make_mock_registry(["weather"])
+    with patch("angie.agents.registry.get_registry", return_value=registry):
+        from angie.api.routers.chat import _extract_mentions
+
+        mentions, cleaned = _extract_mentions("@weather in NYC @weather in LA")
+        assert mentions == [("weather", "agent")]
+        assert "@weather" not in cleaned
+
+
+@patch("angie.config.get_settings")
+def test_extract_mentions_no_mentions(mock_gs):
+    mock_gs.return_value = MagicMock()
+    registry = _make_mock_registry(["weather"])
+    with patch("angie.agents.registry.get_registry", return_value=registry):
+        from angie.api.routers.chat import _extract_mentions
+
+        mentions, cleaned = _extract_mentions("just a normal message")
+        assert mentions == []
+        assert cleaned == "just a normal message"
+
+
+@patch("angie.config.get_settings")
+def test_extract_mentions_invalid_slugs_ignored(mock_gs):
+    mock_gs.return_value = MagicMock()
+    registry = _make_mock_registry(["weather"])
+    with patch("angie.agents.registry.get_registry", return_value=registry):
+        from angie.api.routers.chat import _extract_mentions
+
+        mentions, cleaned = _extract_mentions("@nonexistent hello @weather forecast")
+        assert mentions == [("weather", "agent")]
+        assert "@nonexistent" in cleaned  # invalid slug stays in message
+        assert "@weather" not in cleaned


### PR DESCRIPTION
## Summary

- **Duplicate agent responses**: When the LLM dispatches a task via `dispatch_task`, the dispatched agent slug is now tracked and excluded from subscription auto-notify, preventing the same agent from producing two identical responses
- **Docker worker missing pytest**: Installs `pytest`, `pytest-asyncio`, and `pytest-cov` in `Dockerfile.worker` so the software-dev agent can run tests in cloned repositories
- **Agent acknowledgement**: Sends an immediate "On it" message before `agent.execute()` so users see feedback while long-running agents work (skipped for background auto-notify tasks)

## Test plan

- [x] `make test` — all 597 backend + 99 frontend tests pass
- [x] `make check` — lint clean
- [x] Live test: send "list my github issues" (no @-mention) and verify only one github response
- [ ] `docker compose build worker && docker compose exec worker python -m pytest --version` succeeds
- [ ] Live test: send `@software-dev pick an issue` and verify acknowledgement appears before final result

🤖 Generated with [Claude Code](https://claude.com/claude-code)