### PR TITLE
fix: secure /api/v1/prompts/definitions endpoint (#68)

### DIFF
--- a/src/angie/api/routers/prompts.py
+++ b/src/angie/api/routers/prompts.py
@@ -135,7 +135,7 @@ async def _seed_defaults(user_id: str, session: AsyncSession) -> list[Prompt]:
 
 
 @router.get("/definitions", response_model=list[PreferenceDefinition])
-async def get_definitions():
+async def get_definitions(current_user: User = Depends(get_current_user)):
     """Return the preference category definitions."""
     return PREFERENCE_DEFINITIONS
 
@@ -277,3 +277,4 @@ async def reset_prompts(
     await session.commit()
     await _seed_defaults(current_user.id, session)
     return {"detail": "Prompts reset to defaults"}
+


### PR DESCRIPTION
This PR addresses issue #68 by securing the `/api/v1/prompts/definitions` endpoint to ensure consistent authentication requirements across the `/api/v1/prompts` router.

### Changes Made:

1. Added `Depends(get_current_user)` to the `/definitions` endpoint in `src/angie/api/routers/prompts.py` to require a valid JWT token.
2. Ran the full test suite, and all tests passed successfully (570 passed, 5 skipped).

### Impact:

- Authentication is now required to access `/api/v1/prompts/definitions`, aligning with other endpoints in the `/api/v1/prompts` router.

Closes #68.